### PR TITLE
Update/scielo miner

### DIFF
--- a/pubsub_workers_integrated/worker/miners/arxiv_miner.py
+++ b/pubsub_workers_integrated/worker/miners/arxiv_miner.py
@@ -10,8 +10,6 @@ class ArxivMiner:
     """
     Miner for https://arxiv.org/
     """
-    def __init__(self):
-        pass
 
     class ArxivLocations(mining.PageLocations):
         """

--- a/pubsub_workers_integrated/worker/miners/biorxiv_miner.py
+++ b/pubsub_workers_integrated/worker/miners/biorxiv_miner.py
@@ -10,8 +10,6 @@ class BiorxivMiner:
     """
     Miner for https://www.biorxiv.org/
     """
-    def __init__(self):
-        pass
 
     class BiorxivLocations(mining.PageLocations):
         """ This is a class used to find the schema in the journal """

--- a/pubsub_workers_integrated/worker/miners/ibmcru_miner.py
+++ b/pubsub_workers_integrated/worker/miners/ibmcru_miner.py
@@ -10,8 +10,6 @@ class IbmcRuMiner:
     """
     Miner for http://pbmc.ibmc.msk.ru/
     """
-    def __init__(self):
-        pass
 
     class IbmcLocations(mining.PageLocations):
         """

--- a/pubsub_workers_integrated/worker/miners/medrxiv_miner.py
+++ b/pubsub_workers_integrated/worker/miners/medrxiv_miner.py
@@ -10,8 +10,6 @@ class MedrxivMiner:
     """
     Miner for https://www.medrxiv.org/
     """
-    def __init__(self):
-        pass
 
     class MedrxivLocations(mining.PageLocations):
         category = mining.Element("xpath", "//span[@class='highwire-article-collection-term']")

--- a/pubsub_workers_integrated/worker/miners/preprints_miner.py
+++ b/pubsub_workers_integrated/worker/miners/preprints_miner.py
@@ -10,8 +10,6 @@ class PreprintsMiner:
     """
     Miner for https://preprints.org/
     """
-    def __init__(self):
-        pass
 
     class PreprintsLocations(mining.PageLocations):
         abstract = mining.MetaData("og:description")

--- a/pubsub_workers_integrated/worker/miners/scielo_miner.py
+++ b/pubsub_workers_integrated/worker/miners/scielo_miner.py
@@ -60,23 +60,6 @@ class ScieloMiner:
         ### Utilities Methods ###
         #########################
 
-        # @staticmethod
-        # def TagList(str_list, tag="item"):
-        #     """ Returns a string from a joined list with elements separated by HTML-like tags
-        #     Note:
-        #         This method is overwritting base class centaurminer.MiningEngine
-        #         default `CollectURLs` method.
-        #     Args:
-        #         str_list (list):     List of strings to be joined with HTML-like tags.
-        #         tag (str, optional): Tag used to separate the elements in the form <></>
-        #     Returns:
-        #         A string containing the list elements separated by HTML-like tags,
-        #         None if str_list is None or empty.
-        #     """
-        #     if str_list:
-        #         return ''.join(map(lambda s: f'<{tag}>{s.strip()}</{tag}>', str_list))
-        #     return None
-
         @staticmethod
         def __format_author(author):
             """Formats a single author entry in full name format."""
@@ -108,10 +91,6 @@ class ScieloMiner:
         # def get_id(self, element):
         #     """Return unique identifier for article ID."""
         #     return str(uuid.uuid4())
-
-        # def get_abstract(self, element):
-        #     """Fetch abstract information from article URL."""
-        #     return '\n'.join(self.get(element, several=True))
 
         def get_body(self, element):
             """Gather body text from article URL

--- a/pubsub_workers_integrated/worker/miners/scielo_miner.py
+++ b/pubsub_workers_integrated/worker/miners/scielo_miner.py
@@ -1,6 +1,6 @@
 """
 Scielo miner by Adrian R.
-Edited by Gulnoza Kh. on 2020-11-09
+Edited by Gulnoza Kh. on 2020-12-10
 """
 
 import centaurminer as mining
@@ -11,8 +11,6 @@ class ScieloMiner:
     """
     Miner for https://scielo.org
     """
-    def __init__(self):
-        pass
 
     class ScieloLocations(mining.PageLocations):
         """Locations on the page to be gathered by Selenium webdriver
@@ -30,14 +28,19 @@ class ScieloMiner:
         category = mining.Element("xpath", "//p[@class='categoria']")
         date_publication = mining.Element("xpath", "//div[@class='content']/h3")
         keywords = mining.Element("css_selector", ".trans-abstract > p:last-of-type")
+        language = mining.MetaData("citation_language")
         license = "https://scielo.org/en/about-scielo/open-access-statement/"
         organization_affiliated = mining.Element("css_selector", "p.aff").get_attribute('innerHTML')
         references = mining.Element("css_selector", "p.ref")
         source = mining.MetaData("citation_journal_title")
+        title = mining.Element("css_selector", "p.title")
+
+        # addition to meta-info:
+        title_translated = mining.Element("css_selector", "p.trans-title")
+        abstract_translated = mining.Element("css_selector", ".trans-abstract, .trans-abstract > div.section")
 
         # Null:
         citations = ''
-        language = ''
         search_keyword = ''
         source_impact_factor = ''
 
@@ -56,23 +59,23 @@ class ScieloMiner:
         #########################
         ### Utilities Methods ###
         #########################
-      
-        @staticmethod
-        def TagList(str_list, tag="item"):
-            """ Returns a string from a joined list with elements separated by HTML-like tags
-            Note:
-                This method is overwritting base class centaurminer.MiningEngine
-                default `CollectURLs` method.
-            Args:
-                str_list (list):     List of strings to be joined with HTML-like tags.
-                tag (str, optional): Tag used to separate the elements in the form <></>
-            Returns:
-                A string containing the list elements separated by HTML-like tags,
-                None if str_list is None or empty.
-            """
-            if str_list:
-                return ''.join(map(lambda s: f'<{tag}>{s.strip()}</{tag}>', str_list))
-            return None
+
+        # @staticmethod
+        # def TagList(str_list, tag="item"):
+        #     """ Returns a string from a joined list with elements separated by HTML-like tags
+        #     Note:
+        #         This method is overwritting base class centaurminer.MiningEngine
+        #         default `CollectURLs` method.
+        #     Args:
+        #         str_list (list):     List of strings to be joined with HTML-like tags.
+        #         tag (str, optional): Tag used to separate the elements in the form <></>
+        #     Returns:
+        #         A string containing the list elements separated by HTML-like tags,
+        #         None if str_list is None or empty.
+        #     """
+        #     if str_list:
+        #         return ''.join(map(lambda s: f'<{tag}>{s.strip()}</{tag}>', str_list))
+        #     return None
 
         @staticmethod
         def __format_author(author):
@@ -106,9 +109,9 @@ class ScieloMiner:
         #     """Return unique identifier for article ID."""
         #     return str(uuid.uuid4())
 
-        def get_abstract(self, element):
-            """Fetch abstract information from article URL."""
-            return '\n'.join(self.get(element, several=True))
+        # def get_abstract(self, element):
+        #     """Fetch abstract information from article URL."""
+        #     return '\n'.join(self.get(element, several=True))
 
         def get_body(self, element):
             """Gather body text from article URL
@@ -173,18 +176,18 @@ class ScieloMiner:
         def get_organization_affiliated(self, element):
             """Returns a string with article authors organizations, separated by HTML-like elements"""
             orgs = [o.split('</sup>')[-1] for o in self.get(element, several=True)]
-            return self.TagList(orgs, "orgs")
+            return mining.TagList(orgs, "orgs")
 
         def get_references(self, element):
             """Returns a string with article references, separated by HTML-like elements"""
             reflist = self.get(element, several=True)
             refs = [r.replace('[ Links ]', '').strip('0123456789. ') for r in reflist]
-            return self.TagList(refs, "reference")
+            return mining.TagList(refs, "reference")
 
         def get_authors(self, element):
             """Returns a string with article authors from search engine, separated by HTML-like elements"""
             authors = map(self.__format_author, self.get(element, several=True))
-            return self.TagList(list(dict.fromkeys(authors)), "author")
+            return mining.TagList(list(dict.fromkeys(authors)), "author")
 
         def get_keywords(self, element):
             """Gather article keywords from centaurminer.Element object.
@@ -194,4 +197,16 @@ class ScieloMiner:
                 String comprising keywords separated by HTML-like tags.
             """
             keys = self.__parse_keywords(self.get(element))
-            return self.TagList(keys, "keyword")
+            return mining.TagList(keys, "keyword")
+
+        def get_title_translated(self, element):
+            """Returns a string with translated title/s if any, separated by HTML-like elements"""
+            return mining.TagList(self.get(element, several=True), tag='title_translated')
+
+        def get_abstract_translated(self, element):
+            """Returns a string with translated abstract/s if any, separated by HTML-like elements"""
+            return mining.TagList(self.get(element, several=True), tag='abstract_translated')
+
+        def get_extra_link(self, element):
+            """Returns a string with link to pdf/s if any, separated by HTML-like elements"""
+            return mining.TagList(self.get(element, several=True), tag='pdf_link')

--- a/pubsub_workers_integrated/worker/miners/scielo_miner.py
+++ b/pubsub_workers_integrated/worker/miners/scielo_miner.py
@@ -197,7 +197,9 @@ class ScieloMiner:
                 String comprising keywords separated by HTML-like tags.
             """
             keys = self.__parse_keywords(self.get(element))
-            return mining.TagList(keys, "keyword")
+            if keys:
+                return mining.TagList(keys, "keyword")
+            return None
 
         def get_title_translated(self, element):
             """Returns a string with translated title/s if any, separated by HTML-like elements"""

--- a/pubsub_workers_integrated/worker/site_worker_integrated.py
+++ b/pubsub_workers_integrated/worker/site_worker_integrated.py
@@ -88,8 +88,9 @@ class SiteWorkerIntegrated:
         }
 
         # Scielo specific meta-info
-        if 'title_translated' and 'abstract_translated' in miner.results:
+        if miner.results['title_translated']:
             meta_info['title_translated'] = miner.results['title_translated']
+        if miner.results['abstract_translated']:
             meta_info['abstract_translated'] = miner.results['abstract_translated']
 
         data['meta_info'] = json.dumps(meta_info)

--- a/pubsub_workers_integrated/worker/site_worker_integrated.py
+++ b/pubsub_workers_integrated/worker/site_worker_integrated.py
@@ -46,7 +46,8 @@ class SiteWorkerIntegrated:
         site_worker = self.site_worker_factory(domain, url, self.driver_path)
         return site_worker.scrape_articles()
 
-    def scrape_data(self, miner, url):
+    @staticmethod
+    def scrape_data(miner, url):
         """
         Scrapes data given urls' dataframe, and limit of articles to scrape.
         Uploads data to a given BigQuery table and calls `update_job_status` method
@@ -77,16 +78,19 @@ class SiteWorkerIntegrated:
             # into a datetime object (at midnight)
             "acquisition_date": datetime.combine(date(*[int(x) for x in miner.results['date_aquisition'].split("-")]), time),
         }
-        # if miner.results['date_publication'] is not None:
-        #    data["publication_date"] = datetime.combine(date(*[int(x) for x in miner.results['date_publication'].split("-")]), time)
 
         # Add the meta info
         meta_info = {
-            "references:": miner.results['references'],
+            "references": miner.results['references'],
             "search_keyword": miner.results['search_keyword'],
             "license": miner.results['license'],
             "extra_link": miner.results['extra_link']
         }
+
+        # Scielo specific meta-info
+        if 'title_translated' and 'abstract_translated' in miner.results:
+            meta_info['title_translated'] = miner.results['title_translated']
+            meta_info['abstract_translated'] = miner.results['abstract_translated']
 
         data['meta_info'] = json.dumps(meta_info)
         return data

--- a/pubsub_workers_integrated/worker/worker.py
+++ b/pubsub_workers_integrated/worker/worker.py
@@ -52,7 +52,8 @@ def callback(message):
             print(f"We've got some errors when updating bq: {errors}", flush=True)
         message.ack()
         return
-    data['language'] = status['language']  # Should always be true...
+    if not data['language']:
+        data['language'] = status['language']  # Should always be true...
     print("\nGot data:", flush=True)
     print(*data.items(), sep='\n', flush=True)
 


### PR DESCRIPTION
#### updated fields:
- `title`: gets title from <body> element instead of metadata.
- `language`: gets language from metadata, if any, otherwise gets one from status['language'] table.

#### fields added to meta-info:
- `title_translated`: includes all translated titles in an article, separated by <title_translated> tags.
- `abstract_translated`: includes all translated abstracts in an article, separated by <abstract_translated> tags.
- `extra_link`:  includes all pdf links in an article, separated by <pdf_link> tags.