### PR TITLE
Hotfix: Correct MINER_ID variable used on worker.py

### DIFF
--- a/pubsub_workers_integrated/deploy.sh
+++ b/pubsub_workers_integrated/deploy.sh
@@ -31,10 +31,10 @@ gcloud config set compute/zone $ZONE
 gcloud container clusters create $CLUSTER_NAME --num-nodes=3 --scopes=gke-default,pubsub,bigquery
 gcloud container clusters get-credentials $CLUSTER_NAME
 
-sed -i "s/PROJECT_ID/${PROJECT_ID}/g;s/TOPIC_ID/${TOPIC_ID}/g;s/SUBSCRIBER_ID/${SUBSCRIBER_ID}/g;s/STATUS_TABLE_NAME/${STATUS_TABLE_ID}/g" manifests/pubsub-sender-config.yaml
-sed -i "s/PROJECT_ID/${PROJECT_ID}/g;s/TOPIC_ID/${TOPIC_ID}/g;s/SUBSCRIBER_ID/${SUBSCRIBER_ID}/g;s/STATUS_TABLE_NAME/${STATUS_TABLE_ID}/g;s/DATA_TABLE_NAME/${DATA_TABLE_ID}/g" manifests/pubsub-worker-config.yaml
+sed -i "s|PROJECT_ID|${PROJECT_ID}|g;s|TOPIC_ID|${TOPIC_ID}|g;s|SUBSCRIBER_ID|${SUBSCRIBER_ID}|g;s|STATUS_TABLE_NAME|${STATUS_TABLE_ID}|g" manifests/pubsub-sender-config.yaml
+sed -i "s|PROJECT_ID|${PROJECT_ID}|g;s|TOPIC_ID|${TOPIC_ID}|g;s|SUBSCRIBER_ID|${SUBSCRIBER_ID}|g;s|STATUS_TABLE_NAME|${STATUS_TABLE_ID}|g;s|DATA_TABLE_NAME|${DATA_TABLE_ID}|g" manifests/pubsub-worker-config.yaml
 for i in ${APPS[*]}; do
-    sed -i "s/PROJECT_ID/${PROJECT_ID}/g" manifests/pubsub-${i}.yaml
+    sed -i "s|PROJECT_ID|${PROJECT_ID}|g" manifests/pubsub-${i}.yaml
     kubectl apply -f ./manifests/pubsub-${i}-config.yaml
     kubectl apply -f ./manifests/pubsub-${i}.yaml
 done

--- a/pubsub_workers_integrated/manifests/pubsub-worker.yaml
+++ b/pubsub_workers_integrated/manifests/pubsub-worker.yaml
@@ -50,6 +50,10 @@ spec:
             configMapKeyRef:
               key: DATA_TABLE_ID
               name: pubsub-worker-config
+        - name: MINER_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         # Change here to include your Container URL to pull
         image: gcr.io/PROJECT_ID/pubsub_worker:latest
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
### Major Changes

- Changed `sed` pattern expression as it substitutes the variables placeholders on YAML files. Used 'pipe' (`|`) as the slash might raise some issues, as it's used on addresses.
- Now the `MINER_ID` is generated on the fly by the Kubernetes API, and it corresponds to the pod id.