### PR TITLE
Fix url_builder_integrated

### DIFF
--- a/Integrated_URL_builder/Dockerfile
+++ b/Integrated_URL_builder/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.8.7-buster  AS compiler
+FROM python:3.8.7-buster AS compiler
 LABEL maintainer="yeshwanthreddy789@gmail.com"
 
-WORKDIR /usr/src/ap
+WORKDIR /usr/src/app
 ENV PATH=/root/.local/bin:$PATH
 
 ARG CHROMIUM_VERSION=83.0.4103.116-1~deb10u3

--- a/Integrated_URL_builder/Dockerfile
+++ b/Integrated_URL_builder/Dockerfile
@@ -1,12 +1,12 @@
-FROM python:3.8-buster AS compiler
+FROM python:3.8.7-buster  AS compiler
 LABEL maintainer="yeshwanthreddy789@gmail.com"
 
-WORKDIR /usr/src/app
+WORKDIR /usr/src/ap
 ENV PATH=/root/.local/bin:$PATH
 
 ARG CHROMIUM_VERSION=83.0.4103.116-1~deb10u3
 ARG CHROMEDRIVER_VERSION=83.0.4103.39
-RUN apt-get update && apt-get install -y chromium=$CHROMIUM_VERSION
+RUN apt-get update && apt-get install chromium-common=$CHROMIUM_VERSION -y chromium=$CHROMIUM_VERSION
 RUN curl -LO https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip && \
     unzip chromedriver_linux64.zip -d /usr/lib/chromium-browser						&& \
     ln -s /usr/lib/chromium-browser/chromedriver /usr/local/bin

--- a/Integrated_URL_builder/url_builder_integration.py
+++ b/Integrated_URL_builder/url_builder_integration.py
@@ -377,9 +377,9 @@ class pbmc_url(URL_builder):
     self.total_urls.extend(self.valid_urls[:nums])
     [self._url_list.append(i) for i in self.valid_urls[:nums]]
     self._create_url_schema(self._url_list,self.page_url,lang='ru')
+    self.urls_dataframe = pd.concat([self.urls_dataframe,self._url_schema],ignore_index=True)
     self._send_to_bigquery()
-    print('\n Total no. of URLS sent to BigQuery:'+str(len(self.total_urls)))
-    
+    print('\n Total no. of URLS sent to BigQuery:'+str(len(self.total_urls))) 
 
 class scielo_url(URL_builder):
   """


### PR DESCRIPTION
Fixed issues with Dockerfile that caused `broken package` error by Docker and included a missed line of code in `pbmc url_builder` to create `dataframe` before sending it to bigquery. 